### PR TITLE
Remove test filter option used only by ServiceControl (and not for long)

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ This action does not support the [dotnet test filter syntax](https://learn.micro
 1. No tests were found in an assembly becuase they did not match the filter, as was intended.
 2. No tests were found in an assembly because there was an error in the test adapter package, and valid tests are not being properly executed.
 
-Due to the danger of the second case, filtering is not supported. Instead attributes that implement NUnit's `IApplyToContext` interface can be applied at the method, class, or assembly level and call `Assert.Ignore(reason)` to ignore groups of tests in certain conditions.
+Due to the danger of the second case, filtering is not supported. Instead, attributes that implement NUnit's `IApplyToContext` interface can be applied at the method, class, or assembly level and call `Assert.Ignore(reason)` to ignore groups of tests in certain conditions.
 
 An example of this can be found in SQL Persistence in the [`EngineSpecificTestAttribute`](https://github.com/Particular/NServiceBus.Persistence.Sql/blob/master/src/TestHelper/EngineSpecificTestAttributes/EngineSpecificTestAttribute.cs) class, which is inherited by [other attribute classes](https://github.com/Particular/NServiceBus.Persistence.Sql/tree/master/src/TestHelper/EngineSpecificTestAttributes) for each supported database engine. This makes it possible to use a single `[assembly: SqlServerTest]` to only run tests in that project when a SQL Server connection string is available.
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Basic:
 ```yaml
     steps:
       - name: Run tests
-        uses: Particular/run-tests-action@v1.5.0
+        uses: Particular/run-tests-action@v1.6.0
 ```
 
 With a reset script between each test run:
@@ -21,7 +21,7 @@ With a reset script between each test run:
 ```yaml
     steps:
       - name: Run tests
-        uses: Particular/run-tests-action@v1.5.0
+        uses: Particular/run-tests-action@v1.6.0
         with:
           reset-script: |
             echo "Do whatever is necessary to reset the test infrastructure between runs of each framework"
@@ -33,7 +33,7 @@ In cases where the test matrix subdivides by target framework, you can also shor
 ```yaml
     steps:
       - name: Run tests
-        uses: Particular/run-tests-action@v1.5.0
+        uses: Particular/run-tests-action@v1.6.0
         with:
           framework: net6.0
 ```
@@ -43,7 +43,7 @@ By default, only failed tests are reported. To report warnings for tests that ha
 ```yaml
     steps:
       - name: Run tests
-        uses: Particular/run-tests-action@v1.5.0
+        uses: Particular/run-tests-action@v1.6.0
         with:
           report-warnings: true
 ```
@@ -53,20 +53,23 @@ By default, `dotnet test` uses `x64` as the target platform. This can be overrid
 ```yaml
     steps:
       - name: Run tests
-        uses: Particular/run-tests-action@v1.5.0
+        uses: Particular/run-tests-action@v1.6.0
         with:
           target-platform: x86
 ```
 
-To filter tests use the filter argument together with the [dotnet test filter syntax](https://learn.microsoft.com/en-us/dotnet/core/testing/selective-unit-tests)
+## What about filters?
 
-```yaml
-    steps:
-      - name: Run tests
-        uses: Particular/run-tests-action@v1.5.0
-        with:
-          filter: TestCategory=MyTestCategory
-```
+This action does not support the [dotnet test filter syntax](https://learn.microsoft.com/en-us/dotnet/core/testing/selective-unit-tests). This is because it's impossible to distinguish between the following cases:
+
+1. No tests were found in an assembly becuase they did not match the filter, as was intended.
+2. No tests were found in an assembly because there was an error in the test adapter package, and valid tests are not being properly executed.
+
+Due to the danger of the second case, filtering is not supported. Instead attributes that implement NUnit's `IApplyToContext` interface can be applied at the method, class, or assembly level and call `Assert.Ignore(reason)` to ignore groups of tests in certain conditions.
+
+An example of this can be found in SQL Persistence in the [`EngineSpecificTestAttribute`](https://github.com/Particular/NServiceBus.Persistence.Sql/blob/master/src/TestHelper/EngineSpecificTestAttributes/EngineSpecificTestAttribute.cs) class, which is inherited by [other attribute classes](https://github.com/Particular/NServiceBus.Persistence.Sql/tree/master/src/TestHelper/EngineSpecificTestAttributes) for each supported database engine. This makes it possible to use a single `[assembly: SqlServerTest]` to only run tests in that project when a SQL Server connection string is available.
+
+Using this method also results in visual tests summaries that clearly show which tests were run and which were ignored, making it easy to see if any tests are missing.
 
 ## License
 

--- a/action.yml
+++ b/action.yml
@@ -14,9 +14,6 @@ inputs:
     description: Specifies the RunConfiguration.TargetPlatform for dotnet test. Defaults to 'x64'.
     required: false
     default: x64
-  filter:
-    description: Specifies the filter, if any, to use when running the tests
-    required: false
 runs:
   using: "composite"
   steps:

--- a/run-tests.ps1
+++ b/run-tests.ps1
@@ -54,12 +54,6 @@ if ($Env:REPORT_WARNINGS -eq 'true') {
     $reportWarnings = 'true'
 }
 
-$filter = ''
-
-if ($Env:TEST_FILTER -ne '') {
-    $filter = $($Env:TEST_FILTER)
-}
-
 $exitCode = 0
 $counter = 0
 
@@ -81,13 +75,7 @@ foreach ($framework in $testFrameworks) {
 
         $targetPlatformParam = "RunConfiguration.TargetPlatform=$($Env:TARGET_PLATFORM)"
 
-        if ($filter -ne '') {
-           dotnet test $project.Name --configuration Release --no-build --filter "$filter" --framework $framework --logger "GitHubActions;report-warnings=$reportWarnings" -- RunConfiguration.TreatNoTestsAsError=true $targetPlatformParam
-        }
-        else {
-            dotnet test $project.Name --configuration Release --no-build --framework $framework --logger "GitHubActions;report-warnings=$reportWarnings" -- RunConfiguration.TreatNoTestsAsError=true $targetPlatformParam
-        }
-        
+        dotnet test $project.Name --configuration Release --no-build --framework $framework --logger "GitHubActions;report-warnings=$reportWarnings" -- RunConfiguration.TreatNoTestsAsError=true $targetPlatformParam
 
         Write-Output "::endgroup::"
 


### PR DESCRIPTION
My preference over https://github.com/Particular/run-tests-action/pull/12

The feature was only used by ServiceControl and https://github.com/Particular/ServiceControl/pull/3554 is about to remove that.

Documentation attempts to connect the dots and point developers toward how tests should be filtered between different CI jobs.